### PR TITLE
Add simple interactive assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ ledger.commitTransaction(t);
 System.out.println(ledger.toString());
 ```
 
+After running the example you can ask the assistant about the ledger. When
+executing the `Main` class you will be prompted for commands. For example:
+
+```
+Ask assistant about ledger (type 'exit' to quit):
+> trial balance
+... output of the computed trial balance ...
+```
+
 ## Setup
 
 Accounting uses [lombok](https://projectlombok.org/) to reduce getter and setter code clutter.

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,6 +3,8 @@ import core.TrialBalanceResult;
 import core.chartofaccounts.ChartOfAccounts;
 import core.chartofaccounts.ChartOfAccountsBuilder;
 import core.transaction.AccountingTransaction;
+import assistant.Assistant;
+import java.util.Scanner;
 
 import java.math.BigDecimal;
 
@@ -37,5 +39,18 @@ public class Main {
         // Print trial balance
         TrialBalanceResult trialBalanceResult = ledger.computeTrialBalance();
         System.out.println(trialBalanceResult.toString());
+
+        // Start simple assistant
+        Assistant assistant = new Assistant();
+        try (Scanner scanner = new Scanner(System.in)) {
+            System.out.println("Ask assistant about ledger (type 'exit' to quit):");
+            while (true) {
+                String line = scanner.nextLine();
+                if ("exit".equalsIgnoreCase(line)) {
+                    break;
+                }
+                System.out.println(assistant.handle(line, ledger));
+            }
+        }
     }
 }

--- a/src/main/java/assistant/Assistant.java
+++ b/src/main/java/assistant/Assistant.java
@@ -1,0 +1,24 @@
+package assistant;
+
+import core.Ledger;
+import core.TrialBalanceResult;
+
+public class Assistant {
+    public String handle(String userInput, Ledger ledger) {
+        if (userInput == null || userInput.isBlank()) {
+            return "Please enter a command.";
+        }
+        String normalized = userInput.toLowerCase();
+        if (normalized.contains("trial balance")) {
+            TrialBalanceResult result = ledger.computeTrialBalance();
+            return result.toString();
+        } else if (normalized.startsWith("balance")) {
+            String[] parts = normalized.split("\\s+");
+            if (parts.length == 2) {
+                String accountNumber = parts[1];
+                return ledger.getAccountBalance(accountNumber).toPlainString();
+            }
+        }
+        return "Sorry, I didn't understand that command.";
+    }
+}

--- a/src/test/java/assistant/AssistantTest.java
+++ b/src/test/java/assistant/AssistantTest.java
@@ -1,0 +1,32 @@
+import assistant.Assistant;
+import core.Ledger;
+import core.chartofaccounts.ChartOfAccounts;
+import core.chartofaccounts.ChartOfAccountsBuilder;
+import core.transaction.AccountingTransaction;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static core.account.AccountSide.CREDIT;
+import static core.account.AccountSide.DEBIT;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AssistantTest {
+    @Test
+    public void testHandleTrialBalance() {
+        String cashAccountNumber = "000001";
+        ChartOfAccounts coa = ChartOfAccountsBuilder.create()
+                .addAccount(cashAccountNumber, "Cash", CREDIT)
+                .build();
+        Ledger ledger = new Ledger(coa);
+        AccountingTransaction t = ledger.createTransaction(null)
+                .debit(new BigDecimal(10), cashAccountNumber)
+                .credit(new BigDecimal(10), cashAccountNumber)
+                .build();
+        ledger.commitTransaction(t);
+
+        Assistant assistant = new Assistant();
+        String response = assistant.handle("trial balance", ledger);
+        assertTrue(response.contains("accountNumberToAccountMap"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Assistant class to handle simple ledger questions
- call Assistant from the Main demo
- document assistant usage in README
- add a basic AssistantTest

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbff983e48320bebc8783276fc05d