### PR TITLE
Add trial balance report feature

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -36,6 +36,6 @@ public class Main {
 
         // Print trial balance
         TrialBalanceResult trialBalanceResult = ledger.computeTrialBalance();
-        System.out.println(trialBalanceResult.toString());
+        System.out.println(trialBalanceResult.toReport().toString());
     }
 }

--- a/src/main/java/core/TrialBalanceReport.java
+++ b/src/main/java/core/TrialBalanceReport.java
@@ -1,0 +1,75 @@
+package core;
+
+import com.google.common.base.MoreObjects;
+import core.account.AccountDetails;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Represents a trial balance with debit and credit totals.
+ */
+public class TrialBalanceReport {
+    private final Map<AccountDetails, BigDecimal> debitAmounts =
+            new TreeMap<>(Comparator.comparing(AccountDetails::getAccountNumber));
+    private final Map<AccountDetails, BigDecimal> creditAmounts =
+            new TreeMap<>(Comparator.comparing(AccountDetails::getAccountNumber));
+    private final BigDecimal totalDebit;
+    private final BigDecimal totalCredit;
+    private final boolean balanced;
+
+    public TrialBalanceReport(Map<AccountDetails, BigDecimal> balances) {
+        checkNotNull(balances);
+        BigDecimal debit = BigDecimal.ZERO;
+        BigDecimal credit = BigDecimal.ZERO;
+        for (var entry : balances.entrySet()) {
+            BigDecimal amount = entry.getValue();
+            if (amount.signum() >= 0) {
+                debitAmounts.put(entry.getKey(), amount);
+                debit = debit.add(amount);
+            } else {
+                BigDecimal abs = amount.abs();
+                creditAmounts.put(entry.getKey(), abs);
+                credit = credit.add(abs);
+            }
+        }
+        totalDebit = debit;
+        totalCredit = credit;
+        balanced = totalDebit.compareTo(totalCredit) == 0;
+    }
+
+    public Map<AccountDetails, BigDecimal> getDebitAmounts() {
+        return new TreeMap<>(debitAmounts);
+    }
+
+    public Map<AccountDetails, BigDecimal> getCreditAmounts() {
+        return new TreeMap<>(creditAmounts);
+    }
+
+    public BigDecimal getTotalDebit() {
+        return totalDebit;
+    }
+
+    public BigDecimal getTotalCredit() {
+        return totalCredit;
+    }
+
+    public boolean isBalanced() {
+        return balanced;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("debitAmounts", debitAmounts)
+                .add("creditAmounts", creditAmounts)
+                .add("totalDebit", totalDebit)
+                .add("totalCredit", totalCredit)
+                .add("balanced", balanced)
+                .toString();
+    }
+}

--- a/src/main/java/core/TrialBalanceResult.java
+++ b/src/main/java/core/TrialBalanceResult.java
@@ -25,6 +25,14 @@ public class TrialBalanceResult {
     @Getter
     final private boolean isBalanced;
 
+    public Map<AccountDetails, BigDecimal> getAccountBalances() {
+        return new TreeMap<>(accountDetailsToBalance);
+    }
+
+    public TrialBalanceReport toReport() {
+        return new TrialBalanceReport(accountDetailsToBalance);
+    }
+
     public TrialBalanceResult(Set<Account> accounts) {
         checkNotNull(accounts);
         checkArgument(!accounts.isEmpty());

--- a/src/test/java/TrialBalanceTest.java
+++ b/src/test/java/TrialBalanceTest.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 
 import static core.account.AccountSide.DEBIT;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TrialBalanceTest {
     @Test
@@ -38,5 +39,34 @@ public class TrialBalanceTest {
 
         // Assert
         assertTrue(trialBalance.isBalanced());
+    }
+
+    @Test
+    public void testTrialBalanceReportTotals() {
+        // Arrange
+        String cashAccountNumber = "000001";
+        String checkingAccountNumber = "000002";
+
+        ChartOfAccounts coa = ChartOfAccountsBuilder.create()
+                .addAccount(cashAccountNumber, "Cash", DEBIT)
+                .addAccount(checkingAccountNumber, "Cash", DEBIT)
+                .build();
+        Journal journal = new Journal();
+
+        AccountingTransaction t1 = AccountingTransactionBuilder.create()
+                .debit(new BigDecimal(222), checkingAccountNumber)
+                .credit(new BigDecimal(222), cashAccountNumber)
+                .build();
+        journal.addTransaction(t1);
+        Ledger ledger = new Ledger(journal, coa);
+
+        // Act
+        TrialBalanceResult trialBalance = ledger.computeTrialBalance();
+        var report = trialBalance.toReport();
+
+        // Assert
+        assertTrue(report.isBalanced());
+        assertEquals(new BigDecimal(222), report.getTotalDebit());
+        assertEquals(new BigDecimal(222), report.getTotalCredit());
     }
 }


### PR DESCRIPTION
## Summary
- implement `TrialBalanceReport` to calculate debit/credit totals
- expose `getAccountBalances()` and `toReport()` in `TrialBalanceResult`
- print a trial balance report in `Main`
- test trial balance report totals

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb6a99df883208489c91d31e51b3c